### PR TITLE
NSData support for passwords

### DIFF
--- a/SSKeychain/SSKeychain.h
+++ b/SSKeychain/SSKeychain.h
@@ -76,6 +76,20 @@ extern NSString *const kSSKeychainWhereKey;
 + (NSString *)passwordForService:(NSString *)serviceName account:(NSString *)account;
 + (NSString *)passwordForService:(NSString *)serviceName account:(NSString *)account error:(NSError **)error;
 
+/**
+ Returns a nsdata containing the password for a given account and service, or `nil` if the Keychain doesn't have a
+ password for the given parameters.
+
+ @param serviceName The service for which to return the corresponding password.
+
+ @param account The account for which to return the corresponding password.
+
+ @return Returns a nsdata containing the password for a given account and service, or `nil` if the Keychain doesn't
+ have a password for the given parameters.
+ */
++ (NSData *)passwordDataForService:(NSString *)serviceName account:(NSString *)account;
++ (NSData *)passwordDataForService:(NSString *)serviceName account:(NSString *)account error:(NSError **)error;
+
 
 /**
  Deletes a password from the Keychain.
@@ -104,6 +118,19 @@ extern NSString *const kSSKeychainWhereKey;
 + (BOOL)setPassword:(NSString *)password forService:(NSString *)serviceName account:(NSString *)account;
 + (BOOL)setPassword:(NSString *)password forService:(NSString *)serviceName account:(NSString *)account error:(NSError **)error;
 
+/**
+ Sets a password in the Keychain.
+
+ @param password The password to store in the Keychain.
+
+ @param serviceName The service for which to set the corresponding password.
+
+ @param account The account for which to set the corresponding password.
+
+ @return Returns `YES` on success, or `NO` on failure.
+ */
++ (BOOL)setPasswordData:(NSData *)password forService:(NSString *)serviceName account:(NSString *)account;
++ (BOOL)setPasswordData:(NSData *)password forService:(NSString *)serviceName account:(NSString *)account error:(NSError **)error;
 
 /**
  Returns an array containing the Keychain's accounts, or `nil` if the Keychain has no accounts.

--- a/SSKeychain/SSKeychain.m
+++ b/SSKeychain/SSKeychain.m
@@ -36,6 +36,19 @@ NSString *const kSSKeychainWhereKey = @"svce";
     return query.password;
 }
 
++ (NSData *)passwordDataForService:(NSString *)serviceName account:(NSString *)account {
+	return [self passwordDataForService:serviceName account:account error:nil];
+}
+
++ (NSData *)passwordDataForService:(NSString *)serviceName account:(NSString *)account error:(NSError **)error {
+    SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
+    query.service = serviceName;
+    query.account = account;
+    [query fetch:error];
+
+    return query.passwordData;
+}
+
 
 + (BOOL)deletePasswordForService:(NSString *)serviceName account:(NSString *)account {
 	return [self deletePasswordForService:serviceName account:account error:nil];
@@ -63,6 +76,18 @@ NSString *const kSSKeychainWhereKey = @"svce";
     return [query save:error];
 }
 
++ (BOOL)setPasswordData:(NSData *)password forService:(NSString *)serviceName account:(NSString *)account {
+	return [self setPasswordData:password forService:serviceName account:account error:nil];
+}
+
+
++ (BOOL)setPasswordData:(NSData *)password forService:(NSString *)serviceName account:(NSString *)account error:(NSError **)error {
+    SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
+    query.service = serviceName;
+    query.account = account;
+    query.passwordData = password;
+    return [query save:error];
+}
 
 + (NSArray *)allAccounts {
     return [self accountsForService:nil];


### PR DESCRIPTION
When using some algorithms like diffie-hellman the resulting key is not
a printable string.
This change adds support for storing that kind of keys.

This should have been probably the primary way to add passwords I don't think we want to break the existing installations. 