### PR TITLE
Make the default security stronger

### DIFF
--- a/SSKeychain/SSKeychain.h
+++ b/SSKeychain/SSKeychain.h
@@ -140,8 +140,8 @@ extern NSString *const kSSKeychainWhereKey;
 
  @return Returns the accessibility type.
 
- The return value will be `NULL` or one of the "Keychain Item Accessibility
- Constants" used for determining when a keychain item should be readable.
+ The default return value is `kSecAttrAccessibleWhenUnlocked`. It can be set to one of the
+ "Keychain Item Accessibility Constants" used for determining when a keychain item should be readable.
 
  @see setAccessibilityType
  */
@@ -153,7 +153,7 @@ extern NSString *const kSSKeychainWhereKey;
  @param accessibilityType One of the "Keychain Item Accessibility Constants"
  used for determining when a keychain item should be readable.
 
- If the value is `NULL` (the default), the Keychain default will be used.
+ The default value is `kSecAttrAccessibleWhenUnlocked`, which is the safest option.
 
  @see accessibilityType
  */

--- a/SSKeychain/SSKeychain.m
+++ b/SSKeychain/SSKeychain.m
@@ -78,6 +78,9 @@ NSString *const kSSKeychainWhereKey = @"svce";
 
 #if __IPHONE_4_0 && TARGET_OS_IPHONE
 + (CFTypeRef)accessibilityType {
+    if (!SSKeychainAccessibilityType) {
+		SSKeychainAccessibilityType = kSecAttrAccessibleWhenUnlocked;
+	}
 	return SSKeychainAccessibilityType;
 }
 

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -68,7 +68,17 @@
 	}
 
     NSMutableDictionary *query = [self query];
+#if TARGET_OS_IPHONE
     status = SecItemDelete((__bridge CFDictionaryRef)query);
+#else
+    CFTypeRef result = NULL;
+    [query setObject:@YES forKey:(__bridge id)kSecReturnRef];
+    status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
+    if (status == errSecSuccess) {
+        status = SecKeychainItemDelete((SecKeychainItemRef)result);
+        CFRelease(result);
+    }
+#endif
 
     if (status != errSecSuccess && error != NULL) {
         *error = [[self class] errorWithCode:status];

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -68,17 +68,7 @@
 	}
 
     NSMutableDictionary *query = [self query];
-#if TARGET_OS_IPHONE
     status = SecItemDelete((__bridge CFDictionaryRef)query);
-#else
-    CFTypeRef result = NULL;
-    [query setObject:@YES forKey:(__bridge id)kSecReturnRef];
-    status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
-    if (status == errSecSuccess) {
-        status = SecKeychainItemDelete((SecKeychainItemRef)result);
-        CFRelease(result);
-    }
-#endif
 
     if (status != errSecSuccess && error != NULL) {
         *error = [[self class] errorWithCode:status];


### PR DESCRIPTION
In SSKeychain's doc it says for the AccessibilityType: `If the value is NULL (the default), the Keychain default will be used.`
But I couldn't find in the apple docs what the default is and since this is a wrapper to make it easy for the user/developer I strongly think we should make it as save as possible and Apple recommends as well to always set `kSecAttrAccessibleWhenUnlocked` if possible.