### PR TITLE
Removed different delete for iOS and OS X

### DIFF
--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -68,17 +68,7 @@
 	}
 
     NSMutableDictionary *query = [self query];
-#if TARGET_OS_IPHONE
     status = SecItemDelete((__bridge CFDictionaryRef)query);
-#else
-    CFTypeRef result = NULL;
-    [query setObject:@YES forKey:(__bridge id)kSecReturnRef];
-    status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
-    if (status == errSecSuccess) {
-        status = SecKeychainItemDelete((SecKeychainItemRef)result);
-        CFRelease(result);
-    }
-#endif
 
     if (status != errSecSuccess && error != NULL) {
         *error = [[self class] errorWithCode:status];


### PR DESCRIPTION
I don't see while the function for iOS and OS X should be different. And Apple recommends the use of SecItem over SecKeychainItem so I think there shouldn't be two different Versions of delete.

Run the tests on a Mac Mini 10.8 and the Simulator iOS 7