### PR TITLE
Support for deleting all keychain items matching a query.

### DIFF
--- a/SSKeychain/SSKeychain.m
+++ b/SSKeychain/SSKeychain.m
@@ -32,7 +32,7 @@ NSString *const kSSKeychainWhereKey = @"svce";
     SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
     query.service = serviceName;
     query.account = account;
-    [query fetch:error];
+    [query fetchSingleItem:error];
     return query.password;
 }
 
@@ -46,7 +46,7 @@ NSString *const kSSKeychainWhereKey = @"svce";
     SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
     query.service = serviceName;
     query.account = account;
-    return [query deleteItem:error];
+    return [query deleteItems:error];
 }
 
 
@@ -60,7 +60,7 @@ NSString *const kSSKeychainWhereKey = @"svce";
     query.service = serviceName;
     query.account = account;
     query.password = password;
-    return [query save:error];
+    return [query saveItem:error];
 }
 
 
@@ -72,7 +72,7 @@ NSString *const kSSKeychainWhereKey = @"svce";
 + (NSArray *)accountsForService:(NSString *)serviceName {
     SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
     query.service = serviceName;
-    return [query fetchAll:nil];
+    return [query fetchItems:nil];
 }
 
 

--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -64,16 +64,16 @@
 
  @return `YES` if saving was successful, `NO` otherwise.
  */
-- (BOOL)save:(NSError **)error;
+- (BOOL)saveItem:(NSError **)error;
 
 /**
- Dete keychain items that match the given account, service, and access group.
+ Delete all keychain items that match the given account, service, and access group.
 
  @param error Populated should an error occur.
 
  @return `YES` if saving was successful, `NO` otherwise.
  */
-- (BOOL)deleteItem:(NSError **)error;
+- (BOOL)deleteItems:(NSError **)error;
 
 /**
  Fetch all keychain items that match the given account, service, and access
@@ -85,10 +85,10 @@
  `nil` should an error occur.
  The order of the items is not determined.
  */
-- (NSArray *)fetchAll:(NSError **)error;
+- (NSArray *)fetchItems:(NSError **)error;
 
 /**
- Fetch the keychain item that matches the given account, service, and access
+ Fetch first keychain item that matches the given account, service, and access
  group. The `password` and `passwordData` properties will be populated unless
  an error occurs. The values of `password` and `passwordData` are ignored when
  fetching.
@@ -97,6 +97,6 @@
 
  @return `YES` if fetching was successful, `NO` otherwise.
  */
-- (BOOL)fetch:(NSError **)error;
+- (BOOL)fetchSingleItem:(NSError **)error;
 
 @end

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -26,7 +26,7 @@
 
 #pragma mark - Public
 
-- (BOOL)save:(NSError *__autoreleasing *)error {
+- (BOOL)saveItem:(NSError *__autoreleasing *)error {
     OSStatus status = SSKeychainErrorBadArguments;
     if (!self.service || !self.account || !self.passwordData) {
 		if (error) {
@@ -35,7 +35,7 @@
 		return NO;
 	}
 
-    [self deleteItem:nil];
+    [self deleteItems:nil];
 
     NSMutableDictionary *query = [self query];
     [query setObject:self.passwordData forKey:(__bridge id)kSecValueData];
@@ -58,14 +58,8 @@
 }
 
 
-- (BOOL)deleteItem:(NSError *__autoreleasing *)error {
-    OSStatus status = SSKeychainErrorBadArguments;
-    if (!self.service || !self.account) {
-		if (error) {
-			*error = [[self class] errorWithCode:status];
-		}
-		return NO;
-	}
+- (BOOL)deleteItems:(NSError *__autoreleasing *)error {
+    OSStatus status = errSecSuccess;
 
     NSMutableDictionary *query = [self query];
 #if TARGET_OS_IPHONE
@@ -88,7 +82,7 @@
 }
 
 
-- (NSArray *)fetchAll:(NSError *__autoreleasing *)error {
+- (NSArray *)fetchItems:(NSError *__autoreleasing *)error {
     OSStatus status = SSKeychainErrorBadArguments;
     NSMutableDictionary *query = [self query];
     [query setObject:@YES forKey:(__bridge id)kSecReturnAttributes];
@@ -105,7 +99,7 @@
 }
 
 
-- (BOOL)fetch:(NSError *__autoreleasing *)error {
+- (BOOL)fetchSingleItem:(NSError *__autoreleasing *)error {
     OSStatus status = SSKeychainErrorBadArguments;
 	if (!self.service || !self.account) {
 		if (error) {

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -110,7 +110,7 @@
 
 	CFTypeRef result = NULL;
 	NSMutableDictionary *query = [self query];
-    [query setObject:@YES forKey:(__bridge_transfer id)kSecReturnData];
+    [query setObject:@YES forKey:(__bridge id)kSecReturnData];
     [query setObject:(__bridge id)kSecMatchLimitOne forKey:(__bridge id)kSecMatchLimit];
     status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
 

--- a/Tests/SSKeychainTests.m
+++ b/Tests/SSKeychainTests.m
@@ -34,13 +34,13 @@ static NSString *kSSToolkitTestsLabel = @"SSToolkitLabel";
     query.service = kSSToolkitTestsServiceName;
     query.account = kSSToolkitTestsAccountName;
     query.label = kSSToolkitTestsLabel;
-    STAssertTrue([query save:&error], @"Unable to save item: %@", error);
+    STAssertTrue([query saveItem:&error], @"Unable to save item: %@", error);
     
     // check password
     query = [[SSKeychainQuery alloc] init];
     query.service = kSSToolkitTestsServiceName;
     query.account = kSSToolkitTestsAccountName;
-    STAssertTrue([query fetch:&error], @"Unable to fetch keychain item: %@", error);
+    STAssertTrue([query fetchSingleItem:&error], @"Unable to fetch keychain item: %@", error);
     STAssertEqualObjects(query.password, kSSToolkitTestsPassword, @"Passwords were not equal");
     
     // set password to a dictionary
@@ -49,24 +49,24 @@ static NSString *kSSToolkitTestsLabel = @"SSToolkitLabel";
                                 @"4 8 15 16 23 42", @"string",
                                 nil];
     query.passwordObject = dictionary;
-    STAssertTrue([query save:&error], @"Unable to save item: %@", error);
+    STAssertTrue([query saveItem:&error], @"Unable to save item: %@", error);
     
     // check password
     query = [[SSKeychainQuery alloc] init];
     query.service = kSSToolkitTestsServiceName;
     query.account = kSSToolkitTestsAccountName;
-    STAssertTrue([query fetch:&error], @"Unable to fetch keychain item: %@", error);
+    STAssertTrue([query fetchSingleItem:&error], @"Unable to fetch keychain item: %@", error);
     STAssertEqualObjects(query.passwordObject, dictionary, @"Passwords were not equal");
     
     // check all accounts
     query = [[SSKeychainQuery alloc] init];
-    accounts = [query fetchAll:&error];
+    accounts = [query fetchItems:&error];
     STAssertNotNil(accounts, @"Unable to fetch accounts: %@", error);
     STAssertTrue([self _accounts:accounts containsAccountWithName:kSSToolkitTestsAccountName], @"Matching account was not returned");
     
     // check accounts for service
     query.service = kSSToolkitTestsServiceName;
-    accounts = [query fetchAll:&error];
+    accounts = [query fetchItems:&error];
     STAssertNotNil(accounts, @"Unable to fetch accounts: %@", error);
     STAssertTrue([self _accounts:accounts containsAccountWithName:kSSToolkitTestsAccountName], @"Matching account was not returned");
     
@@ -74,41 +74,41 @@ static NSString *kSSToolkitTestsLabel = @"SSToolkitLabel";
     query = [[SSKeychainQuery alloc] init];
     query.service = kSSToolkitTestsServiceName;
     query.account = kSSToolkitTestsAccountName;
-    STAssertTrue([query deleteItem:&error], @"Unable to delete password: %@", error);
+    STAssertTrue([query deleteItems:&error], @"Unable to delete password: %@", error);
     
     // check if saving with missing informations is handled correctly
     query = [[SSKeychainQuery alloc] init];
     query.service = kSSToolkitTestsServiceName;
     query.account = kSSToolkitTestsAccountName;
-    STAssertFalse([query save:&error], @"Function should return NO as not all needed information is provided: %@", error);
+    STAssertFalse([query saveItem:&error], @"Function should return NO as not all needed information is provided: %@", error);
     
     query = [[SSKeychainQuery alloc] init];
     query.password = kSSToolkitTestsPassword;
     query.account = kSSToolkitTestsAccountName;
-    STAssertFalse([query save:&error], @"Function should return NO as not all needed information is provided: %@", error);
+    STAssertFalse([query saveItem:&error], @"Function should return NO as not all needed information is provided: %@", error);
 
     query = [[SSKeychainQuery alloc] init];
     query.password = kSSToolkitTestsPassword;
     query.service = kSSToolkitTestsServiceName;
-    STAssertFalse([query save:&error], @"Function save should return NO if not all needed information is provided: %@", error);
+    STAssertFalse([query saveItem:&error], @"Function save should return NO if not all needed information is provided: %@", error);
     
     // check if deletion with missing information is handled correctly
     query = [[SSKeychainQuery alloc] init];
     query.account = kSSToolkitTestsAccountName;
-    STAssertFalse([query deleteItem:&error], @"Function deleteItem should return NO if not all needed information is provided: %@", error);
+    STAssertFalse([query deleteItems:&error], @"Function deleteItem should return NO if not all needed information is provided: %@", error);
 
     query = [[SSKeychainQuery alloc] init];
     query.service = kSSToolkitTestsServiceName;
-    STAssertFalse([query deleteItem:&error], @"Function deleteItem should return NO if not all needed information is provided: %@", error);
+    STAssertFalse([query deleteItems:&error], @"Function deleteItem should return NO if not all needed information is provided: %@", error);
     
     // check if fetch handels missing information correctly
     query = [[SSKeychainQuery alloc] init];
     query.account = kSSToolkitTestsAccountName;
-    STAssertFalse([query fetch:&error], @"Function fetch should return NO if not all needed information is provided: %@", error);
+    STAssertFalse([query fetchSingleItem:&error], @"Function fetch should return NO if not all needed information is provided: %@", error);
     
     query = [[SSKeychainQuery alloc] init];
     query.service = kSSToolkitTestsServiceName;
-    STAssertFalse([query fetch:&error], @"Function fetch should return NO if not all needed information is provided: %@", error);
+    STAssertFalse([query fetchSingleItem:&error], @"Function fetch should return NO if not all needed information is provided: %@", error);
 }
 
 - (void)testSSKeychain {


### PR DESCRIPTION
I think that -deleteItem: method of SSKeychainQuery is way too restrictive in its precondition checks. According to its description in the header file it is supposed to delete all items matching a query (and TBH this is what I would've expected as well), but in reality it only allows deleting items with specified service and account.
I also feel that method names in SSKeychainQuery are a bit incoherent with each other, but that's probably very subjective.
This pull request is the way I would've done it, but I guess that for the sake of retaining backwards compatibility a simple addition of a -deleteAll: method or the like will suffice.