### PR TITLE
Better document security issues, see also #42

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -20,10 +20,12 @@ SSKeychain has the following class methods for working with the system keychain:
 + (NSArray *)accountsForService:(NSString *)serviceName;
 + (NSString *)passwordForService:(NSString *)serviceName account:(NSString *)account;
 + (BOOL)deletePasswordForService:(NSString *)serviceName account:(NSString *)account;
++ (void)setAccessibilityType:kSecAttrAccessibleAfterFirstUnlock;
 + (BOOL)setPassword:(NSString *)password forService:(NSString *)serviceName account:(NSString *)account;
 ```
 
 Easy as that. (See [SSKeychain.h](https://github.com/soffes/sskeychain/blob/master/SSKeychain/SSKeychain.h) and [SSKeychainQuery.h](https://github.com/soffes/sskeychain/blob/master/SSKeychain/SSKeychainQuery.h) for all of the methods.)
+
 
 ## Documentation
 
@@ -77,6 +79,10 @@ Obviously, you should do something more sophisticated. You can just call `[error
 
 Working with the keychain is pretty sucky. You should really check for errors and failures. This library doesn't make it any more stable, it just wraps up all of the annoying C APIs.
 
+You also really should not use the default but set the `accessibilityType`.
+`kSecAttrAccessibleWhenUnlocked` should work for most applications. See
+[Apple Documentation](https://developer.apple.com/library/ios/DOCUMENTATION/Security/Reference/keychainservices/Reference/reference.html#//apple_ref/doc/constant_group/Keychain_Item_Accessibility_Constants)
+for other options.
 
 ## Thanks
 

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -20,7 +20,7 @@ SSKeychain has the following class methods for working with the system keychain:
 + (NSArray *)accountsForService:(NSString *)serviceName;
 + (NSString *)passwordForService:(NSString *)serviceName account:(NSString *)account;
 + (BOOL)deletePasswordForService:(NSString *)serviceName account:(NSString *)account;
-+ (void)setAccessibilityType:kSecAttrAccessibleAfterFirstUnlock;
++ (void)setAccessibilityType:(CFTypeRef)accessibilityType;
 + (BOOL)setPassword:(NSString *)password forService:(NSString *)serviceName account:(NSString *)account;
 ```
 

--- a/SSKeychain/SSKeychain.h
+++ b/SSKeychain/SSKeychain.h
@@ -153,7 +153,10 @@ extern NSString *const kSSKeychainWhereKey;
  @param accessibilityType One of the "Keychain Item Accessibility Constants"
  used for determining when a keychain item should be readable.
 
- If the value is `NULL` (the default), the Keychain default will be used.
+ If the value is `NULL` (the default), the Keychain default will be used which
+ is highly insecure. You really should use at least `kSecAttrAccessibleAfterFirstUnlock`
+ for background applications or `kSecAttrAccessibleWhenUnlocked` for all
+ other applications.
 
  @see accessibilityType
  */


### PR DESCRIPTION
Based on @hashier's pull request in
https://github.com/soffes/sskeychain/pull/42 this better documents that
`AccessibilityType` really should be set. It does not change any
defaults but only updates documentation accordingly. So it is 100%
backwards compatible but should help developers to make an informed
decosion about how to store items in the keychain.