### PR TITLE
Conflict fix for #76 (Added support for iOS 8/OS X 10.0 AccessControl (Touch ID) #76)

### DIFF
--- a/SSKeychain.xcodeproj/project.pbxproj
+++ b/SSKeychain.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4412CE1C1A9A372F00C35DE1 /* SSKeychainAccessControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 4412CE1A1A9A372F00C35DE1 /* SSKeychainAccessControl.h */; };
+		4412CE1D1A9A372F00C35DE1 /* SSKeychainAccessControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 4412CE1A1A9A372F00C35DE1 /* SSKeychainAccessControl.h */; };
+		4412CE1E1A9A372F00C35DE1 /* SSKeychainAccessControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 4412CE1B1A9A372F00C35DE1 /* SSKeychainAccessControl.m */; };
+		4412CE1F1A9A372F00C35DE1 /* SSKeychainAccessControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 4412CE1B1A9A372F00C35DE1 /* SSKeychainAccessControl.m */; };
 		E8A6665B1A844D3A00287CA3 /* SSKeychain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8A666341A844CC400287CA3 /* SSKeychain.framework */; };
 		E8A666641A844DB700287CA3 /* SSKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 21CC42EF17DB878300201DDC /* SSKeychain.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E8A666651A844DB700287CA3 /* SSKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 21CC42F017DB878300201DDC /* SSKeychain.m */; };
@@ -58,6 +62,8 @@
 		21CC42F117DB878300201DDC /* SSKeychainQuery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSKeychainQuery.h; sourceTree = "<group>"; };
 		21CC42F217DB878300201DDC /* SSKeychainQuery.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSKeychainQuery.m; sourceTree = "<group>"; };
 		21CC42F917DB87C300201DDC /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		4412CE1A1A9A372F00C35DE1 /* SSKeychainAccessControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSKeychainAccessControl.h; sourceTree = "<group>"; };
+		4412CE1B1A9A372F00C35DE1 /* SSKeychainAccessControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSKeychainAccessControl.m; sourceTree = "<group>"; };
 		E8A666341A844CC400287CA3 /* SSKeychain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SSKeychain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8A6664F1A844CF100287CA3 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E8A666551A844D3A00287CA3 /* SSKeychain iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SSKeychain iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -166,6 +172,8 @@
 				21CC42F017DB878300201DDC /* SSKeychain.m */,
 				21CC42F117DB878300201DDC /* SSKeychainQuery.h */,
 				21CC42F217DB878300201DDC /* SSKeychainQuery.m */,
+				4412CE1A1A9A372F00C35DE1 /* SSKeychainAccessControl.h */,
+				4412CE1B1A9A372F00C35DE1 /* SSKeychainAccessControl.m */,
 			);
 			path = SSKeychain;
 			sourceTree = "<group>";
@@ -177,6 +185,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4412CE1C1A9A372F00C35DE1 /* SSKeychainAccessControl.h in Headers */,
 				E8A666641A844DB700287CA3 /* SSKeychain.h in Headers */,
 				E8A666661A844DB700287CA3 /* SSKeychainQuery.h in Headers */,
 			);
@@ -186,6 +195,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4412CE1D1A9A372F00C35DE1 /* SSKeychainAccessControl.h in Headers */,
 				E8A6668A1A844E5400287CA3 /* SSKeychain.h in Headers */,
 				E8A6668C1A844E5400287CA3 /* SSKeychainQuery.h in Headers */,
 			);
@@ -341,6 +351,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4412CE1E1A9A372F00C35DE1 /* SSKeychainAccessControl.m in Sources */,
 				E8A666671A844DB700287CA3 /* SSKeychainQuery.m in Sources */,
 				E8A666651A844DB700287CA3 /* SSKeychain.m in Sources */,
 			);
@@ -358,6 +369,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4412CE1F1A9A372F00C35DE1 /* SSKeychainAccessControl.m in Sources */,
 				E8A6668D1A844E5400287CA3 /* SSKeychainQuery.m in Sources */,
 				E8A6668B1A844E5400287CA3 /* SSKeychain.m in Sources */,
 			);

--- a/SSKeychain.xcodeproj/project.pbxproj
+++ b/SSKeychain.xcodeproj/project.pbxproj
@@ -56,7 +56,7 @@
 		21CC42AE17DB874300201DDC /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		21CC42C317DB874300201DDC /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		21CC42DB17DB877900201DDC /* SSKeychainTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSKeychainTests.m; sourceTree = "<group>"; };
-		21CC42EE17DB878300201DDC /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/SSKeychain.strings; sourceTree = "<group>"; };
+		21CC42EE17DB878300201DDC /* en */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/SSKeychain.strings; sourceTree = "<group>"; };
 		21CC42EF17DB878300201DDC /* SSKeychain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSKeychain.h; sourceTree = "<group>"; };
 		21CC42F017DB878300201DDC /* SSKeychain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSKeychain.m; sourceTree = "<group>"; };
 		21CC42F117DB878300201DDC /* SSKeychainQuery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSKeychainQuery.h; sourceTree = "<group>"; };

--- a/SSKeychain.xcodeproj/project.pbxproj
+++ b/SSKeychain.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4412CE1C1A9A372F00C35DE1 /* SSKeychainAccessControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 4412CE1A1A9A372F00C35DE1 /* SSKeychainAccessControl.h */; };
-		4412CE1D1A9A372F00C35DE1 /* SSKeychainAccessControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 4412CE1A1A9A372F00C35DE1 /* SSKeychainAccessControl.h */; };
+		4412CE1C1A9A372F00C35DE1 /* SSKeychainAccessControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 4412CE1A1A9A372F00C35DE1 /* SSKeychainAccessControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4412CE1D1A9A372F00C35DE1 /* SSKeychainAccessControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 4412CE1A1A9A372F00C35DE1 /* SSKeychainAccessControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4412CE1E1A9A372F00C35DE1 /* SSKeychainAccessControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 4412CE1B1A9A372F00C35DE1 /* SSKeychainAccessControl.m */; };
 		4412CE1F1A9A372F00C35DE1 /* SSKeychainAccessControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 4412CE1B1A9A372F00C35DE1 /* SSKeychainAccessControl.m */; };
 		E8A6665B1A844D3A00287CA3 /* SSKeychain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8A666341A844CC400287CA3 /* SSKeychain.framework */; };

--- a/SSKeychain/SSKeychainAccessControl.h
+++ b/SSKeychain/SSKeychainAccessControl.h
@@ -33,9 +33,9 @@ typedef NS_ENUM(NSUInteger, SSKeychainAccessibility) {
 };
 
 /** SecAccessControlCreateFlags */
-typedef NS_ENUM(NSInteger, SSKeychainCreateFlags) {
+typedef NS_OPTIONS(NSUInteger, SSKeychainCreateFlags) {
 	/** kSecAccessControlUserPresence */
-	SSKeychainCreateFlagUserPresence = 1 << 0
+	SSKeychainCreateFlagUserPresence = 1UL << 0
 };
 
 extern CFTypeRef getSecAttrAccessibility(SSKeychainAccessibility ssAttr);

--- a/SSKeychain/SSKeychainAccessControl.h
+++ b/SSKeychain/SSKeychainAccessControl.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Sam Soffes. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 /** kSecAttrAccessible */
 typedef NS_ENUM(NSUInteger, SSKeychainAccessibility) {

--- a/SSKeychain/SSKeychainAccessControl.h
+++ b/SSKeychain/SSKeychainAccessControl.h
@@ -7,6 +7,7 @@
 //
 
 @import Foundation;
+@import Security;
 
 /** kSecAttrAccessible */
 typedef NS_ENUM(NSUInteger, SSKeychainAccessibility) {

--- a/SSKeychain/SSKeychainAccessControl.h
+++ b/SSKeychain/SSKeychainAccessControl.h
@@ -1,0 +1,51 @@
+//
+//  SSKeychainAccessControl.h
+//  SSKeychain
+//
+//  Created by Liam Nichols on 01/09/2014.
+//  Copyright (c) 2014 Sam Soffes. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/** kSecAttrAccessible */
+typedef NS_ENUM(NSUInteger, SSKeychainAccessibility) {
+	/** kSecAttrAccessibleWhenUnlocked */
+	SSKeychainAccessibilityWhenUnlocked = 1,
+	
+	/** kSecAttrAccessibleAfterFirstUnlock */
+	SSKeychainAccessibilityAfterFirstUnlock,
+	
+	/** kSecAttrAccessibleAlways */
+	SSKeychainAccessibilityAlways,
+	
+	/** kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly */
+	SSKeychainAccessibilityWhenPasscodeSetThisDeviceOnly,
+	
+	/** kSecAttrAccessibleWhenUnlockedThisDeviceOnly */
+	SSKeychainAccessibilityWhenUnlockedThisDeviceOnly,
+	
+	/** kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly */
+	SSKeychainAccessibilityAfterFisrtUnlockThisDeviceOnly,
+	
+	/** kSecAttrAccessibleAlwaysThisDeviceOnly */
+	SSKeychainAccessibilityAlwaysThisDeviceOnly
+};
+
+/** SecAccessControlCreateFlags */
+typedef NS_ENUM(NSInteger, SSKeychainCreateFlags) {
+	/** kSecAccessControlUserPresence */
+	SSKeychainCreateFlagUserPresence = 1 << 0
+};
+
+extern CFTypeRef getSecAttrAccessibility(SSKeychainAccessibility ssAttr);
+
+@interface SSKeychainAccessControl : NSObject
+
++ (instancetype)accessControlWithAccessibility:(SSKeychainAccessibility)accesibility flags:(SSKeychainCreateFlags)flags;
+
+@property (nonatomic, assign) SSKeychainAccessibility accessibility;
+
+@property (nonatomic, assign) SSKeychainCreateFlags flags;
+
+@end

--- a/SSKeychain/SSKeychainAccessControl.m
+++ b/SSKeychain/SSKeychainAccessControl.m
@@ -1,0 +1,50 @@
+//
+//  SSKeychainAccessControl.m
+//  SSKeychain
+//
+//  Created by Liam Nichols on 01/09/2014.
+//  Copyright (c) 2014 Sam Soffes. All rights reserved.
+//
+
+#import "SSKeychainAccessControl.h"
+
+@implementation SSKeychainAccessControl
+
++ (instancetype)accessControlWithAccessibility:(SSKeychainAccessibility)accesibility flags:(SSKeychainCreateFlags)flags
+{
+	SSKeychainAccessControl *accessControl = [self new];
+	accessControl.accessibility = accesibility;
+	accessControl.flags = flags;
+	return accessControl;
+}
+
+@end
+
+CFTypeRef getSecAttrAccessibility(SSKeychainAccessibility ssAttr)
+{
+	switch (ssAttr) {
+		case SSKeychainAccessibilityAlways:
+			return kSecAttrAccessibleAlways;
+		
+		case SSKeychainAccessibilityWhenUnlocked:
+			return kSecAttrAccessibleWhenUnlocked;
+			
+		case SSKeychainAccessibilityAfterFirstUnlock:
+			return kSecAttrAccessibleAfterFirstUnlock;
+		
+		case SSKeychainAccessibilityAlwaysThisDeviceOnly:
+			return kSecAttrAccessibleAlwaysThisDeviceOnly;
+			
+		case SSKeychainAccessibilityWhenUnlockedThisDeviceOnly:
+			return kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
+			
+		case SSKeychainAccessibilityWhenPasscodeSetThisDeviceOnly:
+			return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
+			
+		case SSKeychainAccessibilityAfterFisrtUnlockThisDeviceOnly:
+			return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
+			
+		default:
+			return NULL;
+	}
+}

--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -10,6 +10,10 @@
 @import Security;
 
 #if __IPHONE_8_0 || __MAC_10_10
+	#define SSKEYCHAIN_ACCESS_CONTROL_AVAILABLE 1
+#endif
+
+#ifdef SSKEYCHAIN_ACCESS_CONTROL_AVAILABLE
 	#import "SSKeychainAccessControl.h"
 #endif
 
@@ -50,13 +54,15 @@ typedef NS_ENUM(NSUInteger, SSKeychainQuerySynchronizationMode) {
 @property (nonatomic) SSKeychainQuerySynchronizationMode synchronizationMode;
 #endif
 
-#if __IPHONE_8_0 || __MAC_10_10
+#if __IPHONE_8_0 && TARGET_OS_IPHONE
 /** kSecUseOperationPrompt */
 @property (nonatomic, copy) NSString *useOperationPrompt;
 
 /** kSecUseNoAuthenticationUI */
 @property (nonatomic, assign) NSNumber *useNoAuthenticationUI;
+#endif
 
+#if SSKEYCHAIN_ACCESS_CONTROL_AVAILABLE
 /** kSecAttrAccessControl */
 @property (nonatomic, strong) SSKeychainAccessControl *accessControl;
 #endif
@@ -145,13 +151,29 @@ typedef NS_ENUM(NSUInteger, SSKeychainQuerySynchronizationMode) {
 
 #ifdef SSKEYCHAIN_SYNCHRONIZATION_AVAILABLE
 /**
- Returns a boolean indicating if keychain synchronization is available on the device at runtime. The #define 
+ Returns a boolean indicating if keychain synchronization is available on the device at runtime. The #define
  SSKEYCHAIN_SYNCHRONIZATION_AVAILABLE is only for compile time. If you are checking for the presence of synchronization,
  you should use this method.
  
  @return A value indicating if keychain synchronization is available
  */
 + (BOOL)isSynchronizationAvailable;
+#endif
+
+
+///-----------------------------
+/// @name Access Control Status
+///-----------------------------
+
+#ifdef SSKEYCHAIN_ACCESS_CONTROL_AVAILABLE
+/**
+ Returns a boolean indicating if keychain access control is available on the device at runtime. The #define
+ SSKEYCHAIN_ACCESS_CONTROL_AVAILABLE is only for compile time. If you are checking for the presence of access control,
+ you should use this method.
+ 
+ @return A value indicating if keychain access control is available
+ */
++ (BOOL)isAccessControlAvailable;
 #endif
 
 @end

--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -78,7 +78,7 @@ typedef NS_ENUM(NSUInteger, SSKeychainQuerySynchronizationMode) {
 
 
 ///------------------------
-/// @name Saving & Deleting
+/// @name Saving, Updating & Deleting
 ///------------------------
 
 /**
@@ -90,6 +90,15 @@ typedef NS_ENUM(NSUInteger, SSKeychainQuerySynchronizationMode) {
  @return `YES` if saving was successful, `NO` otherwise.
  */
 - (BOOL)save:(NSError **)error;
+
+/**
+ Updates the receiver's attributes. 
+ 
+ @param error Populated should an error occur.
+ 
+ @return `YES` if saving was successful, `NO` otherwise.
+ */
+- (BOOL)update:(NSError **)error;
 
 /**
  Delete keychain items that match the given account, service, and access group.

--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -9,6 +9,10 @@
 @import Foundation;
 @import Security;
 
+#if __IPHONE_8_0 || __MAC_10_10
+	#import "SSKeychainAccessControl.h"
+#endif
+
 #if __IPHONE_7_0 || __MAC_10_9
 	// Keychain synchronization available at compile time
 	#define SSKEYCHAIN_SYNCHRONIZATION_AVAILABLE 1
@@ -44,6 +48,17 @@ typedef NS_ENUM(NSUInteger, SSKeychainQuerySynchronizationMode) {
 #ifdef SSKEYCHAIN_SYNCHRONIZATION_AVAILABLE
 /** kSecAttrSynchronizable */
 @property (nonatomic) SSKeychainQuerySynchronizationMode synchronizationMode;
+#endif
+
+#if __IPHONE_8_0 || __MAC_10_10
+/** kSecUseOperationPrompt */
+@property (nonatomic, copy) NSString *useOperationPrompt;
+
+/** kSecUseNoAuthenticationUI */
+@property (nonatomic, assign) NSNumber *useNoAuthenticationUI;
+
+/** kSecAttrAccessControl */
+@property (nonatomic, strong) SSKeychainAccessControl *accessControl;
 #endif
 
 /** Root storage for password information */

--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -14,7 +14,7 @@
 #endif
 
 #ifdef SSKEYCHAIN_ACCESS_CONTROL_AVAILABLE
-	#import "SSKeychainAccessControl.h"
+	#import <SSKeychain/SSKeychainAccessControl.h>
 #endif
 
 #if __IPHONE_7_0 || __MAC_10_9

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -20,6 +20,10 @@
 @synthesize accessGroup = _accessGroup;
 #endif
 
+#ifdef SSKEYCHAIN_ACCESS_CONTROL_AVAILABLE
+@synthesize accessControl = _accessControl;
+#endif
+
 #ifdef SSKEYCHAIN_SYNCHRONIZATION_AVAILABLE
 @synthesize synchronizationMode = _synchronizationMode;
 #endif
@@ -49,10 +53,12 @@
 	}
 #endif
 	
-#if __IPHONE_8_0 || __MAC_10_10
+#if __IPHONE_8_0 && TARGET_OS_IPHONE
 	if (self.useNoAuthenticationUI) {
 		[query setObject:self.useNoAuthenticationUI forKey:(__bridge id)kSecUseNoAuthenticationUI];
 	}
+#endif
+#if SSKEYCHAIN_ACCESS_CONTROL_AVAILABLE
 	if (self.accessControl) {
 		CFErrorRef sacError = NULL;
 		SecAccessControlRef sacObject;
@@ -106,7 +112,7 @@
 	}
 #endif
 	
-#if __IPHONE_8_0 || __MAC_10_10
+#if __IPHONE_8_0 && TARGET_OS_IPHONE
 	if (self.useOperationPrompt) {
 		[query setObject:self.useOperationPrompt forKey:(__bridge id)kSecUseOperationPrompt];
 	}
@@ -157,7 +163,7 @@
 	[query setObject:@YES forKey:(__bridge id)kSecReturnAttributes];
 	[query setObject:(__bridge id)kSecMatchLimitAll forKey:(__bridge id)kSecMatchLimit];
 
-#if __IPHONE_8_0 || __MAC_10_10
+#if __IPHONE_8_0 && TARGET_OS_IPHONE
 	if (self.useOperationPrompt) {
 		[query setObject:self.useOperationPrompt forKey:(__bridge id)kSecUseOperationPrompt];
 	}
@@ -188,7 +194,7 @@
 	[query setObject:@YES forKey:(__bridge id)kSecReturnData];
 	[query setObject:(__bridge id)kSecMatchLimitOne forKey:(__bridge id)kSecMatchLimit];
 	
-#if __IPHONE_8_0 || __MAC_10_10
+#if __IPHONE_8_0 && TARGET_OS_IPHONE
 	if (self.useOperationPrompt) {
 		[query setObject:self.useOperationPrompt forKey:(__bridge id)kSecUseOperationPrompt];
 	}
@@ -246,6 +252,21 @@
 	return floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1;
 #else
 	return floor(NSFoundationVersionNumber) > NSFoundationVersionNumber10_8_4;
+#endif
+}
+#endif
+
+
+#pragma mark - Access Control Status
+
+#ifdef SSKEYCHAIN_ACCESS_CONTROL_AVAILABLE
++ (BOOL)isAccessControlAvailable {
+#if TARGET_OS_IPHONE
+	// Apple suggested way to check for 8.0 at runtime
+	// https://developer.apple.com/library/ios/documentation/userexperience/conceptual/transitionguide/SupportingEarlieriOS.html
+	return floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_7_1;
+#else
+	return floor(NSFoundationVersionNumber) > NSFoundationVersionNumber10_9_2;
 #endif
 }
 #endif

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -82,6 +82,44 @@
 	return (status == errSecSuccess);
 }
 
+- (BOOL)update:(NSError *__autoreleasing *)error
+{
+	OSStatus status = SSKeychainErrorBadArguments;
+	if (!self.service || !self.account || !self.passwordData) {
+		if (error) {
+			*error = [[self class] errorWithCode:status];
+		}
+		return NO;
+	}
+	
+	NSMutableDictionary *query = [self query];
+	NSMutableDictionary *changes = [NSMutableDictionary dictionary];
+	
+	[changes setObject:self.passwordData forKey:(__bridge id)kSecValueData];
+	if (self.label) {
+		[changes setObject:self.label forKey:(__bridge id)kSecAttrLabel];
+	}
+#if __IPHONE_4_0 && TARGET_OS_IPHONE
+	CFTypeRef accessibilityType = [SSKeychain accessibilityType];
+	if (accessibilityType) {
+		[changes setObject:(__bridge id)accessibilityType forKey:(__bridge id)kSecAttrAccessible];
+	}
+#endif
+	
+#if __IPHONE_8_0 || __MAC_10_10
+	if (self.useOperationPrompt) {
+		[changes setObject:self.useOperationPrompt forKey:(__bridge id)kSecUseOperationPrompt];
+	}
+#endif
+	
+	status = SecItemUpdate((__bridge CFDictionaryRef)query, (__bridge CFDictionaryRef)changes);
+	
+	if (status != errSecSuccess && error != NULL) {
+		*error = [[self class] errorWithCode:status];
+	}
+	
+	return (status == errSecSuccess);
+}
 
 - (BOOL)deleteItem:(NSError *__autoreleasing *)error {
 	OSStatus status = SSKeychainErrorBadArguments;

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -108,7 +108,7 @@
 	
 #if __IPHONE_8_0 || __MAC_10_10
 	if (self.useOperationPrompt) {
-		[changes setObject:self.useOperationPrompt forKey:(__bridge id)kSecUseOperationPrompt];
+		[query setObject:self.useOperationPrompt forKey:(__bridge id)kSecUseOperationPrompt];
 	}
 #endif
 	


### PR DESCRIPTION
I've rebased the implementation made by @liamnichols (:thumbsup: btw) from #76 and fixed all the conflicts.
I needed the bug fix for #84 so I thought I'd merge in all the changes...

I've also added a similar runtime and compile time check for access control (3e7a31b)