### PR TITLE
Add error parameters to keychain accessor methods

### DIFF
--- a/SSKeychain/SSKeychain.h
+++ b/SSKeychain/SSKeychain.h
@@ -113,6 +113,7 @@ extern NSString *const kSSKeychainWhereKey;
  accounts. The order of the objects in the array isn't defined.
  */
 + (NSArray *)allAccounts;
++ (NSArray *)allAccounts:(NSError *__autoreleasing *)error;
 
 
 /**
@@ -128,6 +129,7 @@ extern NSString *const kSSKeychainWhereKey;
  doesn't have any accounts for the given `serviceName`. The order of the objects in the array isn't defined.
  */
 + (NSArray *)accountsForService:(NSString *)serviceName;
++ (NSArray *)accountsForService:(NSString *)serviceName error:(NSError *__autoreleasing *)error;
 
 
 #pragma mark - Configuration

--- a/SSKeychain/SSKeychain.m
+++ b/SSKeychain/SSKeychain.m
@@ -65,14 +65,24 @@ NSString *const kSSKeychainWhereKey = @"svce";
 
 
 + (NSArray *)allAccounts {
-	return [self accountsForService:nil];
+	return [self allAccounts:nil];
+}
+
+
++ (NSArray *)allAccounts:(NSError *__autoreleasing *)error {
+    return [self accountsForService:nil error:error];
 }
 
 
 + (NSArray *)accountsForService:(NSString *)serviceName {
-	SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
-	query.service = serviceName;
-	return [query fetchAll:nil];
+	return [self accountsForService:serviceName error:nil];
+}
+
+
++ (NSArray *)accountsForService:(NSString *)serviceName error:(NSError *__autoreleasing *)error {
+    SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
+    query.service = serviceName;
+    return [query fetchAll:error];
 }
 
 


### PR DESCRIPTION
This PR adds the possibility to get to the underlying `NSError *` when using `allAccounts` or `accountForService:`.