### PR TITLE
Added accessibilityType parameter to query when fetching all keychain it...

### DIFF
--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -93,6 +93,12 @@
 	NSMutableDictionary *query = [self query];
 	[query setObject:@YES forKey:(__bridge id)kSecReturnAttributes];
 	[query setObject:(__bridge id)kSecMatchLimitAll forKey:(__bridge id)kSecMatchLimit];
+#if __IPHONE_4_0 && TARGET_OS_IPHONE
+	CFTypeRef accessibilityType = [SSKeychain accessibilityType];
+	if (accessibilityType) {
+		[query setObject:(__bridge id)accessibilityType forKey:(__bridge id)kSecAttrAccessible];
+	}
+#endif
 
 	CFTypeRef result = NULL;
 	status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);


### PR DESCRIPTION
When app tryed to obtain accounts for service in background mode on blocked device, it got status '-25308' (User interaction is not allowed) despite the accounts had been saved with accessibilityType kSecAttrAccessibleAlways or kSecAttrAccessibleAfterFirstUnlock. 
Adding accessibilityType parameter to query in fetchAll: method resolved this problem.