### PR TITLE
Revert @import to #import for cedar compatibility.

### DIFF
--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2013-2014 Sam Soffes. All rights reserved.
 //
 
-@import Foundation;
-@import Security;
+#import <Foundation/Foundation.h>
+#import <Security/Security.h>
 
 #if __IPHONE_7_0 || __MAC_10_9
 	// Keychain synchronization available at compile time


### PR DESCRIPTION
When using this framework in a project that uses Cedar for a test framework the @import fails when running specs. This is because cedar tests are written in objective c++ which doesn't recognize @import. 

Cedar:
https://github.com/pivotal/cedar