### PR TITLE
Fixing unused set of an OSStatus variable.

### DIFF
--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -92,7 +92,6 @@
 
 
 - (NSArray *)fetchAll:(NSError *__autoreleasing *)error {
-	OSStatus status = SSKeychainErrorBadArguments;
 	NSMutableDictionary *query = [self query];
 	[query setObject:@YES forKey:(__bridge id)kSecReturnAttributes];
 	[query setObject:(__bridge id)kSecMatchLimitAll forKey:(__bridge id)kSecMatchLimit];
@@ -104,7 +103,7 @@
 #endif
 
 	CFTypeRef result = NULL;
-	status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
+	OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
 	if (status != errSecSuccess && error != NULL) {
 		*error = [[self class] errorWithCode:status];
 		return nil;


### PR DESCRIPTION
The status variable is initially set and then before it's used, it's reset to another value.  This change eliminates the redundant initial setting of the variable.