### PR TITLE
Fix error "Include of non-modular header inside framework module"

### DIFF
--- a/Sources/SSKeychain.h
+++ b/Sources/SSKeychain.h
@@ -12,8 +12,6 @@
 	#import <Foundation/Foundation.h>
 #endif
 
-#import <SSKeychain/SSKeychainQuery.h>
-
 /**
  Error code specific to SSKeychain that can be returned in NSError objects.
  For codes returned by the operating system, refer to SecBase.h for your

--- a/Sources/SSKeychain.m
+++ b/Sources/SSKeychain.m
@@ -8,6 +8,8 @@
 
 #import "SSKeychain.h"
 
+#import <SSKeychain/SSKeychainQuery.h>
+
 NSString *const kSSKeychainErrorDomain = @"com.samsoffes.sskeychain";
 NSString *const kSSKeychainAccountKey = @"acct";
 NSString *const kSSKeychainCreatedAtKey = @"cdat";


### PR DESCRIPTION
- Fix error "Include of non-modular header inside framework module" in swift based projects
- fixes #117