### PR TITLE
Allows SSKeychain to be used in CocoaTouch Frameworks

### DIFF
--- a/Sources/SSKeychain.m
+++ b/Sources/SSKeychain.m
@@ -7,8 +7,7 @@
 //
 
 #import "SSKeychain.h"
-
-#import <SSKeychain/SSKeychainQuery.h>
+#import "SSKeychainQuery.h"
 
 NSString *const kSSKeychainErrorDomain = @"com.samsoffes.sskeychain";
 NSString *const kSSKeychainAccountKey = @"acct";


### PR DESCRIPTION
When developing a CocoaTouch framework as a pod that relies on this library, the pod will fail to lint properly using the angle imports. It must have quote imports in order to lint properly and be successfully compiled within the host application.

This is especially important for frameworks written in swift where the `Allow Non-modular Imports` build directive has no effect. 